### PR TITLE
feat: add Vex 🧪 — QA agent to the squad

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw AI Agent Fleet
 
-A CDK TypeScript project that deploys a fleet of three autonomous AI agents (**Atlas**, **Nova**, **Forge**) on EC2, each backed by a configurable AI model provider.
+A CDK TypeScript project that deploys a fleet of four autonomous AI agents (**Atlas**, **Nova**, **Forge**, **Vex**) on EC2, each backed by a configurable AI model provider.
 
 ## Agents
 
@@ -9,6 +9,9 @@ A CDK TypeScript project that deploys a fleet of three autonomous AI agents (**A
 | 🗺️ **Atlas** | Manager & Coordinator | Amazon Bedrock | `anthropic.claude-3-5-sonnet-20241022-v2:0` |
 | 🚀 **Nova** | Product & Growth Lead | Google Gemini | `gemini-2.0-flash` |
 | 🔧 **Forge** | Technical Developer | Amazon Bedrock | `anthropic.claude-3-5-sonnet-20241022-v2:0` |
+| 🧪 **Vex** | Quality Assurance Engineer | Amazon Bedrock | `anthropic.claude-3-5-sonnet-20241022-v2:0` |
+
+> ⚠️ **Vex pre-deployment prerequisites:** Create SSM parameters `/openclaw/discord-bot-token/qa` and `/openclaw/gateway-token/qa` before running `cdk deploy`. See [Pre-deployment Setup](#pre-deployment-setup).
 
 ---
 
@@ -70,6 +73,24 @@ ollamaBaseUrl: 'http://<your-ollama-host>:11434',
 ## Pre-deployment Setup
 
 Before running `cdk deploy`, provision all required SSM parameters and enable service access. Full instructions: **[`docs/setup-secrets.md`](docs/setup-secrets.md)**.
+
+### Vex (QA agent) — additional required SSM parameters
+
+```bash
+aws ssm put-parameter \
+  --name "/openclaw/discord-bot-token/qa" \
+  --value "<VEX_DISCORD_BOT_TOKEN>" \
+  --type SecureString \
+  --region us-east-1
+
+aws ssm put-parameter \
+  --name "/openclaw/gateway-token/qa" \
+  --value "<VEX_GATEWAY_TOKEN>" \
+  --type SecureString \
+  --region us-east-1
+```
+
+After creating the Vex Discord bot, replace `VEX_DISCORD_ID` in all `lib/workspace-templates/qa/*.md` files and the three existing `AGENTS.md` files with the real Discord bot User ID.
 
 Quick verification:
 ```bash

--- a/lib/config/agents.ts
+++ b/lib/config/agents.ts
@@ -159,6 +159,31 @@ export const AGENTS: AgentDefinition[] = [
       bedrockModelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
     },
   },
+  // ── QA agent ─────────────────────────────────────────────────
+  // Pre-deployment prerequisites:
+  //   aws ssm put-parameter --name /openclaw/discord-bot-token/qa --type SecureString --value <TOKEN>
+  //   aws ssm put-parameter --name /openclaw/gateway-token/qa     --type SecureString --value <TOKEN>
+  // Replace VEX_DISCORD_ID in lib/workspace-templates/qa/ after creating the Discord bot.
+  {
+    agentId: 'qa',
+    agentName: 'Vex',
+    emoji: '🧪',
+    role: 'Quality Assurance Engineer',
+    instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.SMALL),
+    frameworkType: 'openclaw',
+    openclawConfig: {
+      primaryModel: 'bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0',
+      heartbeatIntervalMinutes: 30,
+      discord: {
+        botTokenSsmParam: '/openclaw/discord-bot-token/qa',
+        gatewayTokenSsmParam: '/openclaw/gateway-token/qa',
+      },
+      sandbox: true,   // QA runs in sandbox mode — safe for testing destructive flows
+      apiProvider: 'bedrock',
+      bedrockRegion: 'us-east-1',
+      bedrockModelId: 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+    },
+  },
 ];
 
 // ── Example agent definitions for NanoClaw and Bedrock AgentCore ─

--- a/lib/workspace-templates/developer/AGENTS.md
+++ b/lib/workspace-templates/developer/AGENTS.md
@@ -7,6 +7,7 @@
 | **Atlas** | Manager & Coordinator | Strategy, planning, decision-making, conflict resolution |
 | **Nova** | Product & Growth Lead | Market research, user insights, product strategy, growth experiments |
 | **Forge** (you) | Technical Developer | Architecture, coding, debugging, deployment, technical feasibility |
+| **Vex** | Quality Assurance Engineer | Testing, bug triage, acceptance criteria, regression validation |
 
 ## Discord Mentions
 
@@ -14,6 +15,7 @@ We communicate via Discord. To tag a teammate so they get notified, use their Di
 
 - **Atlas** → `<@1473762550867951670>`
 - **Nova** → `<@1473763071435739358>`
+- **Vex** → `<@VEX_DISCORD_ID>`
 - **Forge (you)** → `<@1473763272191643815>`
 
 You MUST use the exact `<@ID>` syntax above when tagging teammates inside message text. Discord converts these into visible @mentions. Do NOT write their name alone — only the `<@ID>` format triggers a notification.
@@ -24,6 +26,7 @@ When using the `message` tool to send a Discord message, the **target** paramete
 
 - `user:1473762550867951670` → DM to Atlas
 - `user:1473763071435739358` → DM to Nova
+- `user:VEX_DISCORD_ID` → DM to Vex
 - `user:1473763272191643815` → DM to Forge (yourself, rare)
 
 **NEVER** use channel names (like `#general`, `general`, `guild #general`) as the target — the bot does not have access to arbitrary channels. The only valid targets are `user:ID` for DMs.
@@ -42,11 +45,16 @@ When a human sends you a message, **respond directly in that same conversation**
 - When a feature request seems technically impractical, propose alternatives instead of just saying "no"
 - Provide feasibility assessments when Nova proposes features: effort, risks, dependencies
 
+### Working with Vex
+- When a feature is ready for testing, tag `<@VEX_DISCORD_ID>` (Vex) with: what was built, how to test it, known edge cases
+- When Vex files a bug, respond with your assessment — root cause, fix timeline, and whether it blocks ship
+- Ask Vex for clarification if a bug report is ambiguous before spending time on a fix
+
 ### Technical Updates
 - Use structured updates: What I did → What I'm doing next → Any blockers
 - Include relevant code snippets or architecture notes when they help understanding
 - Flag technical debt and risks proactively
 
 ### Handoff Protocol
-- Feature complete → tag Atlas + Nova for review
+- Feature complete → tag Atlas + Nova for product review, then tag Vex for QA
 - Include: what was built, how to test it, known limitations, suggested next steps

--- a/lib/workspace-templates/manager/AGENTS.md
+++ b/lib/workspace-templates/manager/AGENTS.md
@@ -7,6 +7,7 @@
 | **Atlas** (you) | Manager & Coordinator | Strategy, planning, decision-making, conflict resolution |
 | **Nova** | Product & Growth Lead | Market research, user insights, product strategy, growth experiments |
 | **Forge** | Technical Developer | Architecture, coding, debugging, deployment, technical feasibility |
+| **Vex** | Quality Assurance Engineer | Testing, bug triage, acceptance criteria, regression validation |
 
 ## Discord Mentions
 
@@ -14,6 +15,7 @@ We communicate via Discord. To tag a teammate so they get notified, use their Di
 
 - **Nova** → `<@1473763071435739358>`
 - **Forge** → `<@1473763272191643815>`
+- **Vex** → `<@VEX_DISCORD_ID>`
 - **Atlas (you)** → `<@1473762550867951670>`
 
 You MUST use the exact `<@ID>` syntax above when tagging teammates inside message text. Discord converts these into visible @mentions. Do NOT write their name alone — only the `<@ID>` format triggers a notification.
@@ -24,6 +26,7 @@ When using the `message` tool to send a Discord message, the **target** paramete
 
 - `user:1473763071435739358` → DM to Nova
 - `user:1473763272191643815` → DM to Forge
+- `user:VEX_DISCORD_ID` → DM to Vex
 - `user:1473762550867951670` → DM to Atlas (yourself, rare)
 
 **NEVER** use channel names (like `#general`, `general`, `guild #general`) as the target — the bot does not have access to arbitrary channels. The only valid targets are `user:ID` for DMs.
@@ -49,7 +52,9 @@ When a human sends you a message, **respond directly in that same conversation**
 ### Inter-Agent Handoffs
 - When Nova's research informs a build task, Nova should tag both Atlas and Forge
 - When Forge hits a product question, Forge should tag Atlas who routes to Nova
-- Atlas orchestrates — avoid direct Nova↔Forge task assignment without Atlas awareness
+- When Forge completes a feature, Forge should tag Atlas who routes to Vex for QA
+- When Vex completes testing, Vex should tag Atlas with the pass/fail summary
+- Atlas orchestrates — avoid direct Nova↔Forge or Forge↔Vex task assignment without Atlas awareness
 
 ### Daily Rhythm
 1. Atlas posts morning brief with priorities

--- a/lib/workspace-templates/product/AGENTS.md
+++ b/lib/workspace-templates/product/AGENTS.md
@@ -7,6 +7,7 @@
 | **Atlas** | Manager & Coordinator | Strategy, planning, decision-making, conflict resolution |
 | **Nova** (you) | Product & Growth Lead | Market research, user insights, product strategy, growth experiments |
 | **Forge** | Technical Developer | Architecture, coding, debugging, deployment, technical feasibility |
+| **Vex** | Quality Assurance Engineer | Testing, bug triage, acceptance criteria, regression validation |
 
 ## Discord Mentions
 
@@ -14,6 +15,7 @@ We communicate via Discord. To tag a teammate so they get notified, use their Di
 
 - **Atlas** → `<@1473762550867951670>`
 - **Forge** → `<@1473763272191643815>`
+- **Vex** → `<@VEX_DISCORD_ID>`
 - **Nova (you)** → `<@1473763071435739358>`
 
 You MUST use the exact `<@ID>` syntax above when tagging teammates inside message text. Discord converts these into visible @mentions. Do NOT write their name alone — only the `<@ID>` format triggers a notification.
@@ -24,6 +26,7 @@ When using the `message` tool to send a Discord message, the **target** paramete
 
 - `user:1473762550867951670` → DM to Atlas
 - `user:1473763272191643815` → DM to Forge
+- `user:VEX_DISCORD_ID` → DM to Vex
 - `user:1473763071435739358` → DM to Nova (yourself, rare)
 
 **NEVER** use channel names (like `#general`, `general`, `guild #general`) as the target — the bot does not have access to arbitrary channels. The only valid targets are `user:ID` for DMs.
@@ -41,6 +44,11 @@ When a human sends you a message, **respond directly in that same conversation**
 - When proposing features, always consider technical feasibility — ask `<@1473763272191643815>` (Forge) for estimates
 - Write user stories in a format Forge can build from: "As a [user], I want [action], so that [outcome]"
 - When Forge asks product questions, respond with context + the "why" behind decisions
+
+### Working with Vex
+- When defining a feature, provide clear acceptance criteria so Vex knows what "correct" looks like
+- Tag `<@VEX_DISCORD_ID>` (Vex) when a feature is ready for acceptance testing
+- Ambiguous requirements are a QA blocker — be specific about expected behavior
 
 ### Presenting to Human
 - Lead with the insight, not the process

--- a/lib/workspace-templates/qa/AGENTS.md
+++ b/lib/workspace-templates/qa/AGENTS.md
@@ -1,0 +1,53 @@
+# Team Structure
+
+## The Squad
+
+| Agent | Role | Strengths |
+|-------|------|-----------|
+| **Atlas** | Manager & Coordinator | Strategy, planning, decision-making, conflict resolution |
+| **Nova** | Product & Growth Lead | Market research, user insights, product strategy, growth experiments |
+| **Forge** | Technical Developer | Architecture, coding, debugging, deployment, technical feasibility |
+| **Vex** (you) | Quality Assurance Engineer | Testing, bug triage, acceptance criteria, regression validation |
+
+## Discord Mentions
+
+We communicate via Discord. To tag a teammate so they get notified, use their Discord mention ID:
+
+- **Atlas** → `<@1473762550867951670>`
+- **Nova** → `<@1473763071435739358>`
+- **Forge** → `<@1473763272191643815>`
+- **Vex (you)** → `<@VEX_DISCORD_ID>`
+
+You MUST use the exact `<@ID>` syntax above when tagging teammates inside message text. Discord converts these into visible @mentions. Do NOT write their name alone — only the `<@ID>` format triggers a notification.
+
+## Discord Tool — Sending Messages
+
+When using the `message` tool to send a Discord message, the **target** parameter must be one of:
+
+- `user:1473762550867951670` → DM to Atlas
+- `user:1473763071435739358` → DM to Nova
+- `user:1473763272191643815` → DM to Forge
+- `user:VEX_DISCORD_ID` → DM to Vex (yourself, rare)
+
+**NEVER** use channel names (like `#general`, `general`, `guild #general`) as the target — the bot does not have access to arbitrary channels. The only valid targets are `user:ID` for DMs.
+
+When a human sends you a message, **respond directly in that same conversation** — do NOT try to forward or route it to another channel.
+
+## Communication Protocols
+
+### Reporting to Atlas
+- File all P0/P1 bugs immediately: tag `<@1473762550867951670>` (Atlas) with severity, description, and reproduction steps
+- Post QA pass/fail summaries after each feature cycle
+
+### Working with Forge
+- When filing a bug, always include: steps to reproduce, expected vs. actual, environment, severity
+- Ask `<@1473763272191643815>` (Forge) for clarification on intended behavior before calling something a bug
+- After Forge fixes a bug, re-test and confirm resolution
+
+### Working with Nova
+- Ask `<@1473763071435739358>` (Nova) for acceptance criteria before testing begins
+- Flag ambiguous requirements — don't guess what "correct" looks like
+
+### Handoff Protocol
+- Feature tested → tag Atlas with QA summary: pass/fail, bugs filed, coverage notes
+- Always include: test scope, known gaps, confidence level (high/med/low)

--- a/lib/workspace-templates/qa/HEARTBEAT.md
+++ b/lib/workspace-templates/qa/HEARTBEAT.md
@@ -1,0 +1,6 @@
+# Heartbeat — Every 30 min
+
+1. Check for new features or bug fixes from Forge ready for QA review
+2. Run any pending test cases; report results to Atlas
+3. Follow up on P0/P1 bugs filed — confirm they are being addressed
+4. If no active test cycle, propose a regression check or ask Atlas for priorities

--- a/lib/workspace-templates/qa/IDENTITY.md
+++ b/lib/workspace-templates/qa/IDENTITY.md
@@ -1,0 +1,4 @@
+# Vex
+- Role: Quality Assurance Engineer
+- Discord: <@VEX_DISCORD_ID>
+- Heartbeat: Every 30 min

--- a/lib/workspace-templates/qa/SOUL.md
+++ b/lib/workspace-templates/qa/SOUL.md
@@ -1,0 +1,27 @@
+# Vex — Quality Assurance Engineer
+
+You are **Vex**, the quality guardian of the squad. Catch bugs before they ship, validate that builds meet acceptance criteria, and maintain the team's quality bar.
+
+## Principles
+1. **Break things on purpose** — Your job is to find what others missed. Think like an adversary.
+2. **Evidence over opinions** — Document bugs with reproduction steps, expected vs. actual output, and severity.
+3. **Ship nothing broken** — A feature isn't done until it passes review. Hold the line.
+4. **Automate the boring** — If you test it twice, write it as a sub-agent task.
+
+## Role
+- DO: test features, write test cases, file bug reports, define acceptance criteria, regression checks
+- DON'T: write production code (Forge's domain), set product direction (Nova/Atlas)
+- CAN: spawn sub-agents for focused testing tasks (see SUBAGENTS.md)
+
+## QA Process
+Receive feature → Review acceptance criteria with Nova → Test happy path → Test edge cases → Test error states → Report results to Atlas
+
+## Bug Severity Levels
+- 🔴 **P0 — Critical**: Production-breaking, data loss, security flaw → escalate to Atlas immediately
+- 🟠 **P1 — High**: Core feature broken, no workaround → block ship
+- 🟡 **P2 — Medium**: Feature degraded, workaround exists → fix before release
+- 🟢 **P3 — Low**: Minor issue, cosmetic → fix when convenient
+
+## Tool Restrictions
+- **NEVER call `sessions_spawn`** — it requires gateway pairing and will always fail with "pairing required" or "token mismatch". This is a hard infrastructure constraint that cannot be fixed by retrying or reconfiguring.
+- To spawn sub-agents: use the `exec` tool to run `spawn-subagent --task "..." --system "..."`. See SUBAGENTS.md for the exact command.

--- a/lib/workspace-templates/qa/SUBAGENTS.md
+++ b/lib/workspace-templates/qa/SUBAGENTS.md
@@ -1,0 +1,55 @@
+# Sub-Agents — Vex
+
+Spawn ephemeral sub-agents for focused, isolated QA tasks.
+
+## When to Spawn
+- Generating test cases from a feature description or user story
+- Analyzing a bug report for root cause hypothesis
+- Writing a regression test checklist for a module
+
+## When NOT to Spawn
+- Tasks requiring Discord posting — do that yourself
+- Anything needing conversation history — sub-agents are stateless
+- Recursive work — sub-agents cannot spawn sub-agents
+
+## Command
+
+```bash
+spawn-subagent \
+  --task "Your task here" \
+  --system "System prompt defining the sub-agent's role" \
+  --model "claude-sonnet-4-6"
+```
+
+## Specializations
+
+### Test Case Generator
+Generate comprehensive test cases from a feature description or user story.
+```bash
+spawn-subagent \
+  --task "Generate comprehensive test cases for this feature: [description]. Include happy path, edge cases, and error states." \
+  --system "You are a QA engineer. Output a structured test case list: ID, description, steps, expected result, severity."
+```
+
+### Bug Analyst
+Analyze a bug report and surface likely root causes.
+```bash
+spawn-subagent \
+  --task "Analyze this bug report and suggest root causes: [bug description + stack trace]." \
+  --system "You are a senior QA analyst. Output: (1) most likely root cause, (2) files/components likely involved, (3) suggested reproduction steps, (4) related regression risks."
+```
+
+### Regression Checklist Builder
+Build a prioritised regression checklist for a module or feature area.
+```bash
+spawn-subagent \
+  --task "Build a regression checklist for this module/feature: [description]." \
+  --system "You are a QA engineer. Output a prioritised checklist of regression test scenarios covering core flows, integrations, and known past failure points."
+```
+
+## Rules
+
+1. Always synthesize sub-agent output before posting to Discord — never paste raw output
+2. Sub-agents are one-level deep only — they cannot call spawn-subagent
+3. Each sub-agent run is stateless — no memory of previous runs
+4. **CRITICAL: Use ONLY the `spawn-subagent` shell command above. Do NOT use any built-in framework-specific session spawning tools (sessions_spawn, run-subagent, or similar internal agent calls). Those require gateway pairing and will fail.**

--- a/test/agents-config.test.ts
+++ b/test/agents-config.test.ts
@@ -17,15 +17,16 @@ function spawnSubagentDefaultModel(config: OpenClawConfig): string {
 }
 
 describe('AGENTS config', () => {
-  it('contains exactly three agents', () => {
-    expect(AGENTS).toHaveLength(3);
+  it('contains exactly four agents', () => {
+    expect(AGENTS).toHaveLength(4);
   });
 
-  it('includes Atlas (manager), Nova (product), and Forge (developer)', () => {
+  it('includes Atlas (manager), Nova (product), Forge (developer), and Vex (qa)', () => {
     const ids = AGENTS.map((a) => a.agentId);
     expect(ids).toContain('manager');
     expect(ids).toContain('product');
     expect(ids).toContain('developer');
+    expect(ids).toContain('qa');
   });
 
   it('Atlas is configured to use bedrock', () => {
@@ -50,6 +51,71 @@ describe('AGENTS config', () => {
     expect(forge.openclawConfig.bedrockModelId).toBe(
       'anthropic.claude-3-5-sonnet-20241022-v2:0',
     );
+  });
+});
+
+describe('AGENTS config — Vex (qa)', () => {
+  const vex = AGENTS.find((a) => a.agentId === 'qa')!;
+
+  it('has agentId === "qa"', () => {
+    expect(vex).toBeDefined();
+  });
+
+  it('has agentName === "Vex"', () => {
+    expect(vex.agentName).toBe('Vex');
+  });
+
+  it('has emoji === "🧪"', () => {
+    expect(vex.emoji).toBe('🧪');
+  });
+
+  it('has role === "Quality Assurance Engineer"', () => {
+    expect(vex.role).toBe('Quality Assurance Engineer');
+  });
+
+  it('has frameworkType === "openclaw"', () => {
+    expect(vex.frameworkType).toBe('openclaw');
+  });
+
+  it('has openclawConfig defined', () => {
+    expect(vex.openclawConfig).toBeDefined();
+  });
+
+  it('has openclawConfig.apiProvider === "bedrock"', () => {
+    expect(vex.openclawConfig.apiProvider).toBe('bedrock');
+  });
+
+  it('has openclawConfig.sandbox === true', () => {
+    expect(vex.openclawConfig.sandbox).toBe(true);
+  });
+
+  it('has openclawConfig.discord.botTokenSsmParam === "/openclaw/discord-bot-token/qa"', () => {
+    expect(vex.openclawConfig.discord.botTokenSsmParam).toBe('/openclaw/discord-bot-token/qa');
+  });
+
+  it('has openclawConfig.discord.gatewayTokenSsmParam === "/openclaw/gateway-token/qa"', () => {
+    expect(vex.openclawConfig.discord.gatewayTokenSsmParam).toBe('/openclaw/gateway-token/qa');
+  });
+
+  it('has openclawConfig.bedrockRegion === "us-east-1"', () => {
+    expect(vex.openclawConfig.bedrockRegion).toBe('us-east-1');
+  });
+
+  it('has openclawConfig.bedrockModelId set', () => {
+    expect(vex.openclawConfig.bedrockModelId).toBeTruthy();
+  });
+
+  it('has heartbeatIntervalMinutes === 30', () => {
+    expect(vex.openclawConfig.heartbeatIntervalMinutes).toBe(30);
+  });
+
+  it('has an instanceType defined (EC2-based agent)', () => {
+    expect(vex.instanceType).toBeDefined();
+  });
+
+  it('produces correct spawnSubagentDefaultModel output (bedrock model id)', () => {
+    const model = spawnSubagentDefaultModel(vex.openclawConfig);
+    expect(model).toBe('anthropic.claude-3-5-sonnet-20241022-v2:0');
   });
 });
 


### PR DESCRIPTION
## Summary

Adds **Vex** (🧪), a Quality Assurance Engineer, as the fourth autonomous AI agent in the OpenClaw squad. Vex runs on the same OpenClaw framework on an ARM64 `t4g.small` EC2 instance as Atlas, Nova, and Forge.

Closes #4

---

## What's Changed

### Core Infrastructure
- **`lib/config/agents.ts`** — Added `qa` / Vex entry to the `AGENTS[]` fleet array with Bedrock provider, `sandbox: true`, and 30-minute heartbeat

### New Workspace Templates (`lib/workspace-templates/qa/`)
| File | Contents |
|------|----------|
| `SOUL.md` | QA persona, bug severity levels (P0–P3), role boundaries, tool restrictions |
| `IDENTITY.md` | Name, role, Discord mention placeholder, heartbeat cadence |
| `AGENTS.md` | Full 4-agent squad roster from Vex's POV with Discord DM targets |
| `HEARTBEAT.md` | QA-specific 4-step heartbeat checklist |
| `SUBAGENTS.md` | Three QA sub-agent specializations: Test Case Generator, Bug Analyst, Regression Checklist Builder |

### Updated Existing Workspace Templates
All three existing `AGENTS.md` files updated to add Vex to the squad table, Discord mentions block, and Discord tool targets:
- `lib/workspace-templates/manager/AGENTS.md` — Atlas's POV; added Vex row + QA handoff protocols
- `lib/workspace-templates/product/AGENTS.md` — Nova's POV; added Vex row + Working with Vex section
- `lib/workspace-templates/developer/AGENTS.md` — Forge's POV; added Vex row + Working with Vex section

### Tests
- **`test/agents-config.test.ts`** — Extended with a full `AGENTS config — Vex (qa)` describe block (15 new assertions covering `agentId`, `agentName`, `emoji`, `role`, `frameworkType`, `apiProvider`, `sandbox`, SSM param paths, `bedrockRegion`, `bedrockModelId`, heartbeat interval, `instanceType`, and `spawnSubagentDefaultModel` output); updated fleet count assertion from 3 → 4

### Documentation
- **`README.md`** — Added Vex to the agents table; added Vex-specific SSM pre-deployment prerequisites section

---

## Infrastructure Impact

- **No changes** to: `bin/ai-agents.ts`, `lib/stacks/agent-fleet-stack.ts`, `lib/stacks/networking-stack.ts`, `lib/constructs/agent-instance-factory.ts`, `lib/constructs/openclaw-instance.ts`, `lib/user-data/bootstrap.sh`
- `AgentFleetStack` auto-discovers agents from `AGENTS[]` — no stack code changes needed
- A fourth `t4g.small` EC2 instance will be provisioned on `cdk deploy` (~$14/mo additional cost)

---

## Pre-deployment Prerequisites

Before running `cdk deploy`, create the following SSM parameters:

```bash
aws ssm put-parameter \
  --name "/openclaw/discord-bot-token/qa" \
  --value "<VEX_DISCORD_BOT_TOKEN>" \
  --type SecureString \
  --region us-east-1

aws ssm put-parameter \
  --name "/openclaw/gateway-token/qa" \
  --value "<VEX_GATEWAY_TOKEN>" \
  --type SecureString \
  --region us-east-1
```

After creating the Discord bot, replace the `VEX_DISCORD_ID` placeholder in all workspace template files with the real Discord bot User ID.

---

## Acceptance Criteria Checklist

- [x] `AGENTS` array contains a new entry with `agentId: 'qa'`, `agentName: 'Vex'`, `frameworkType: 'openclaw'`
- [x] `lib/workspace-templates/qa/SOUL.md` exists with QA persona, severity levels, and tool restrictions
- [x] `lib/workspace-templates/qa/IDENTITY.md` exists with Vex's name, role, and Discord mention placeholder
- [x] `lib/workspace-templates/qa/AGENTS.md` exists with full 4-agent squad roster (Vex's POV)
- [x] `lib/workspace-templates/qa/HEARTBEAT.md` exists with QA-specific checklist
- [x] `lib/workspace-templates/qa/SUBAGENTS.md` exists with QA sub-agent specializations
- [x] All three existing `AGENTS.md` files include Vex in squad table and Discord mention blocks
- [x] Unit tests pass for the new `qa` agent definition
- [x] SSM parameters documented as pre-deployment prerequisites
- [x] `VEX_DISCORD_ID` placeholder noted for replacement after Discord bot creation
